### PR TITLE
Сформирован механизм добавления тегов к новости

### DIFF
--- a/backend/controllers/NewsController.php
+++ b/backend/controllers/NewsController.php
@@ -4,6 +4,7 @@ namespace backend\controllers;
 
 use common\models\Author;
 use common\models\Rubric;
+use common\models\Tag;
 use Yii;
 use backend\models\News;
 use backend\models\NewsSearch;
@@ -70,7 +71,9 @@ class NewsController extends Controller
     {
         $model = new News();
 
-        //получения списка авторов для дальнейшей связи их с новостью
+        $allTags = ArrayHelper::map(Tag::find()->all(), 'id', 'tag_name');
+
+        //получение списка авторов для дальнейшей связи их с новостью
         $authorsList = ArrayHelper::map(Author::find()->all(), 'id','name');
 
         //получение списка рубрик в формате id => название. В post-запрос передается id
@@ -83,7 +86,8 @@ class NewsController extends Controller
         return $this->render('create', [
             'model' => $model,
             'rubrics' => $rubrics,
-            'authorsList' => $authorsList
+            'authorsList' => $authorsList,
+            'data' => $allTags
         ]);
     }
 
@@ -97,6 +101,7 @@ class NewsController extends Controller
     public function actionUpdate($id)
     {
         $model = $this->findModel($id);
+        $allTags = ArrayHelper::map(Tag::find()->all(), 'id', 'tag_name');
 
         //получения списка авторов для дальнейшей связи их с новостью
         $authorsList = ArrayHelper::map(Author::find()->all(), 'id','name');
@@ -112,6 +117,7 @@ class NewsController extends Controller
             'model' => $model,
             'rubrics' => $rubrics,
             'authorsList' => $authorsList,
+            'data' => $allTags
         ]);
     }
 

--- a/backend/controllers/TagController.php
+++ b/backend/controllers/TagController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace backend\controllers;
+
+use Yii;
+use common\models\Tag;
+use common\models\TagSearch;
+use yii\web\Controller;
+use yii\web\NotFoundHttpException;
+use yii\filters\VerbFilter;
+use yii\web\Response;
+
+class TagController extends Controller
+{
+    /**
+     * @inheritdoc
+     */
+    public function behaviors()
+    {
+        return [
+            'verbs' => [
+                'class' => VerbFilter::class,
+                'actions' => [
+                    'delete' => ['POST'],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Lists all Tag models.
+     * @return mixed
+     */
+    public function actionIndex()
+    {
+        $searchModel = new TagSearch();
+        $dataProvider = $searchModel->search(Yii::$app->request->queryParams);
+
+        return $this->render('index', [
+            'searchModel' => $searchModel,
+            'dataProvider' => $dataProvider,
+        ]);
+    }
+
+
+    /**
+     * Creates a new Tag model.
+     * If creation is successful, the browser will be redirected to the 'view' page.
+     * @return mixed
+     */
+    public function actionCreate()
+    {
+        $model = new Tag();
+
+        if ($model->load(Yii::$app->request->post()) && $model->save()) {
+            return $this->redirect('index');
+        }
+
+        return $this->render('create', [
+            'model' => $model,
+        ]);
+    }
+
+    /**
+     * Updates an existing Tag model.
+     * If update is successful, the browser will be redirected to the 'view' page.
+     * @param integer $id
+     * @return mixed
+     * @throws NotFoundHttpException if the model cannot be found
+     */
+    public function actionUpdate($id)
+    {
+        $model = $this->findModel($id);
+
+        if ($model->load(Yii::$app->request->post()) && $model->save()) {
+            return $this->redirect('index');
+        }
+
+        return $this->render('update', [
+            'model' => $model,
+        ]);
+    }
+
+    /**
+     * Deletes an existing Tag model.
+     * If deletion is successful, the browser will be redirected to the 'index' page.
+     * @param integer $id
+     * @return mixed
+     * @throws NotFoundHttpException if the model cannot be found
+     */
+    public function actionDelete($id)
+    {
+        $this->findModel($id)->delete();
+
+        return $this->redirect(['index']);
+    }
+
+
+    /**
+     * Finds the Tag model based on its primary key value.
+     * If the model is not found, a 404 HTTP exception will be thrown.
+     * @param integer $id
+     * @return Tag the loaded model
+     * @throws NotFoundHttpException if the model cannot be found
+     */
+    protected function findModel($id)
+    {
+        if (($model = Tag::findOne($id)) !== null) {
+            return $model;
+        }
+
+        throw new NotFoundHttpException('The requested page does not exist.');
+    }
+}

--- a/backend/models/News.php
+++ b/backend/models/News.php
@@ -3,17 +3,22 @@
 namespace backend\models;
 
 use common\models\AuthorNews;
+use common\models\NewsTag;
 use common\models\Rubric;
+use common\models\Tag;
 
 /**
  * Class News
  * @package backend\models
  * @property array $authorsList
+ * @property  array $tagsList;
  */
 class News extends \common\models\News
 {
 
-    public $authorsList =[];
+    public $authorsList = [];
+    public $tagsList = [];
+
     public function attributeLabels()
     {
         $attributeLabels = parent::attributeLabels();
@@ -28,25 +33,53 @@ class News extends \common\models\News
     {
         $rules = parent::rules();
         $rules[] = ['authorsList', 'safe'];
+        $rules[] = ['tagsList', 'safe'];
         return $rules;
     }
+
 
     public function afterSave($insert, $changedAttributes)
     {
         //Проверка на добавление авторов через форму
-        if (!empty($this->authorsList)){
+        if (!empty($this->authorsList)) {
 
             //Если автор(ы) задан(ы), удаляется предыдущий список. Если автор не выбирался, список останется прежним.
             AuthorNews::deleteAll(['news_id' => $this->id]);
 
             //Добавление выбранных авторов для подписанных публикаций через связующую таблицу
-            foreach ($this->authorsList as $authorId){
+            foreach ($this->authorsList as $authorId) {
                 $addAuthors = new AuthorNews();
                 $addAuthors->author_id = $authorId;
                 $addAuthors->news_id = $this->id;
                 $addAuthors->save();
             }
         }
+
+        //связь новости с тегами после успешного сохранения новости через связующую модель NewsTag
+        if (!empty($this->tagsList)) {
+            //если теги заданы через форму, предыдущий список обнуляется
+            NewsTag::deleteAll(['news_id' => $this->id]);
+            foreach ($this->tagsList as $tagId) {
+                $addTagsToArticle = new NewsTag();
+                $addTagsToArticle->news_id = $this->id;
+
+                //при добавлении нового Тега из формы в любом случае приходит строка. Если пришел id сохраненной модели,
+                //, берется он. Если же передана строка с  названием нового тега, модели с таким
+                //id нет (что очевидно) => создается новый тег, сохраняется в БД и берется его id
+                if (Tag::findOne(['id' => $tagId])) {
+                    $addTagsToArticle->tag_id = $tagId;
+                } else {
+                    $newTag = new Tag();
+                    $newTag->tag_name = $tagId;
+                    if ($newTag->save()) {
+                        $addTagsToArticle->tag_id = $newTag->id;
+                    }
+                }
+
+                $addTagsToArticle->save();
+            }
+        }
+
         parent::afterSave($insert, $changedAttributes);
     }
 
@@ -55,5 +88,10 @@ class News extends \common\models\News
         //Автоматически задается значение атрибута "id Темы", получаем его исходя из выбранной Рубрики
         $this->theme_id = Rubric::findOne(['id' => $this->rubric_id])->theme_id;
         return parent::beforeSave($insert);
+    }
+
+    public function beforeValidate()
+    {
+        return parent::beforeValidate();
     }
 }

--- a/backend/views/news/_form.php
+++ b/backend/views/news/_form.php
@@ -2,6 +2,8 @@
 
 use yii\helpers\Html;
 use yii\widgets\ActiveForm;
+use kartik\select2\Select2;
+use yii\helpers\ArrayHelper;
 
 /* @var $this yii\web\View */
 /* @var $model backend\models\News */
@@ -26,6 +28,16 @@ use yii\widgets\ActiveForm;
         [
                 'multiple' => true,
         ]);?>
+    <?= $form->field($model, 'tagsList[]')->widget(Select2::class,[
+        'data' => $data,
+        'maintainOrder' => true,
+        'options' => ['multiple' => true],
+        'pluginOptions' => [
+            'tags' => true,
+            'maximumInputLength' => 10
+        ],
+    ]);
+    ?>
 
     <div class="form-group">
         <?= Html::submitButton('Сохранить', ['class' => 'btn btn-success']) ?>

--- a/backend/views/news/create.php
+++ b/backend/views/news/create.php
@@ -18,6 +18,7 @@ $this->params['breadcrumbs'][] = $this->title;
         'model' => $model,
         'rubrics' => $rubrics,
         'authorsList' => $authorsList,
+        'data' => $data
     ]) ?>
 
 </div>

--- a/backend/views/news/update.php
+++ b/backend/views/news/update.php
@@ -18,6 +18,7 @@ $this->params['breadcrumbs'][] = 'Обновить';
         'model' => $model,
         'rubrics' => $rubrics,
         'authorsList' => $authorsList,
+        'data' => $data
     ]) ?>
 
 </div>

--- a/backend/views/news/view.php
+++ b/backend/views/news/view.php
@@ -4,6 +4,7 @@ use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
 use yii\widgets\DetailView;
 
+
 /* @var $this yii\web\View */
 /* @var $model backend\models\News */
 
@@ -32,6 +33,14 @@ $this->params['breadcrumbs'][] = $this->title;
             'title',
             'lead',
             'text:ntext',
+            [
+                'attribute' => 'tags',
+                'value' => function ($data) {
+                    $tags = ArrayHelper::getColumn($data->tags, 'tag_name');
+                    $tagsList = implode(', ', $tags);
+                    return $tagsList;
+                },
+            ],
             'theme.theme_title',
             'rubric.rubric_title',
             'user.full_name',
@@ -45,7 +54,6 @@ $this->params['breadcrumbs'][] = $this->title;
             ],
             'created_at',
             'updated_at',
-            'slug',
         ],
     ]) ?>
 </div>

--- a/backend/views/tag/_form.php
+++ b/backend/views/tag/_form.php
@@ -1,0 +1,23 @@
+<?php
+
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
+
+/* @var $this yii\web\View */
+/* @var $model common\models\Tag */
+/* @var $form yii\widgets\ActiveForm */
+?>
+
+<div class="tag-form">
+
+    <?php $form = ActiveForm::begin(); ?>
+
+    <?= $form->field($model, 'tag_name')->textInput(['maxlength' => true]) ?>
+
+    <div class="form-group">
+        <?= Html::submitButton('Сохранить', ['class' => 'btn btn-success']) ?>
+    </div>
+
+    <?php ActiveForm::end(); ?>
+
+</div>

--- a/backend/views/tag/_search.php
+++ b/backend/views/tag/_search.php
@@ -1,0 +1,31 @@
+<?php
+
+use yii\helpers\Html;
+use yii\widgets\ActiveForm;
+
+/* @var $this yii\web\View */
+/* @var $model common\models\TagSearch */
+/* @var $form yii\widgets\ActiveForm */
+?>
+
+<div class="tag-search">
+
+    <?php $form = ActiveForm::begin([
+        'action' => ['index'],
+        'method' => 'get',
+    ]); ?>
+
+    <?= $form->field($model, 'id') ?>
+
+    <?= $form->field($model, 'tag_name') ?>
+
+    <?= $form->field($model, 'slug') ?>
+
+    <div class="form-group">
+        <?= Html::submitButton('Search', ['class' => 'btn btn-primary']) ?>
+        <?= Html::resetButton('Reset', ['class' => 'btn btn-default']) ?>
+    </div>
+
+    <?php ActiveForm::end(); ?>
+
+</div>

--- a/backend/views/tag/create.php
+++ b/backend/views/tag/create.php
@@ -1,0 +1,21 @@
+<?php
+
+use yii\helpers\Html;
+
+
+/* @var $this yii\web\View */
+/* @var $model common\models\Tag */
+
+$this->title = 'Добавить тег';
+$this->params['breadcrumbs'][] = ['label' => 'Теги', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+<div class="tag-create">
+
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <?= $this->render('_form', [
+        'model' => $model,
+    ]) ?>
+
+</div>

--- a/backend/views/tag/index.php
+++ b/backend/views/tag/index.php
@@ -1,0 +1,35 @@
+<?php
+
+use yii\helpers\Html;
+use yii\grid\GridView;
+
+/* @var $this yii\web\View */
+/* @var $searchModel common\models\TagSearch */
+/* @var $dataProvider yii\data\ActiveDataProvider */
+
+$this->title = 'Все теги';
+$this->params['breadcrumbs'][] = $this->title;
+?>
+<div class="tag-index">
+
+    <h1><?= Html::encode($this->title) ?></h1>
+    <?php // echo $this->render('_search', ['model' => $searchModel]); ?>
+
+    <p>
+        <?= Html::a('Добавить тег', ['create'], ['class' => 'btn btn-success']) ?>
+    </p>
+
+    <?= GridView::widget([
+        'dataProvider' => $dataProvider,
+        'filterModel' => $searchModel,
+        'options' => ['style' => 'width:50%'],
+        'columns' => [
+            'tag_name',
+            [
+                    'class' => 'yii\grid\ActionColumn',
+                    'template' => '{update}{delete}',
+                    'options' => ['style' => 'width:10%'],
+            ],
+        ],
+    ]); ?>
+</div>

--- a/backend/views/tag/update.php
+++ b/backend/views/tag/update.php
@@ -1,0 +1,21 @@
+<?php
+
+use yii\helpers\Html;
+
+/* @var $this yii\web\View */
+/* @var $model common\models\Tag */
+
+$this->title = 'Изменить тег';
+$this->params['breadcrumbs'][] = ['label' => 'Теги', 'url' => ['index']];
+$this->params['breadcrumbs'][] = ['label' => $model->id, 'url' => ['view', 'id' => $model->id]];
+$this->params['breadcrumbs'][] = 'Изменить';
+?>
+<div class="tag-update">
+
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <?= $this->render('_form', [
+        'model' => $model,
+    ]) ?>
+
+</div>

--- a/backend/views/tag/view.php
+++ b/backend/views/tag/view.php
@@ -1,0 +1,37 @@
+<?php
+
+use yii\helpers\Html;
+use yii\widgets\DetailView;
+
+/* @var $this yii\web\View */
+/* @var $model common\models\Tag */
+
+$this->title = $model->id;
+$this->params['breadcrumbs'][] = ['label' => 'Теги', 'url' => ['index']];
+$this->params['breadcrumbs'][] = $this->title;
+?>
+<div class="tag-view">
+
+    <h1><?= Html::encode($this->title) ?></h1>
+
+    <p>
+        <?= Html::a('Изменить тег', ['update', 'id' => $model->id], ['class' => 'btn btn-primary']) ?>
+        <?= Html::a('Удалить тег', ['delete', 'id' => $model->id], [
+            'class' => 'btn btn-danger',
+            'data' => [
+                'confirm' => 'Действительно удалить этот тег?',
+                'method' => 'post',
+            ],
+        ]) ?>
+    </p>
+
+    <?= DetailView::widget([
+        'model' => $model,
+        'attributes' => [
+            'id',
+            'tag_name',
+            'slug',
+        ],
+    ]) ?>
+
+</div>

--- a/common/models/News.php
+++ b/common/models/News.php
@@ -55,7 +55,8 @@ class News extends \yii\db\ActiveRecord
             [['created_at', 'updated_at'], 'safe'],
             [['title', 'lead'], 'string', 'max' => 100],
             [['slug'], 'string', 'max' => 150],
-            [['slug'], 'unique'],
+            [['slug'], 'unique',],
+            [['title'], 'unique', 'message' => 'Такой заголовок уже был'],
             [['image_id'], 'exist', 'skipOnError' => true, 'targetClass' => Image::className(), 'targetAttribute' => ['image_id' => 'id']],
             [['rubric_id'], 'exist', 'skipOnError' => true, 'targetClass' => Rubric::className(), 'targetAttribute' => ['rubric_id' => 'id']],
             [['theme_id'], 'exist', 'skipOnError' => true, 'targetClass' => Theme::className(), 'targetAttribute' => ['theme_id' => 'id']],
@@ -101,6 +102,7 @@ class News extends \yii\db\ActiveRecord
             'created_at' => 'Создано',
             'updated_at' => 'Обновлено',
             'slug' => 'В адресной строке',
+            'tags' => 'Теги',
         ];
     }
 
@@ -155,10 +157,10 @@ class News extends \yii\db\ActiveRecord
     /**
      * @return \yii\db\ActiveQuery
      */
-    public function getNewsTags()
+    /*public function getNewsTags()
     {
         return $this->hasMany(NewsTag::class, ['news_id' => 'id']);
-    }
+    }*/
 
     /**
      * @return \yii\db\ActiveQuery

--- a/common/models/TagSearch.php
+++ b/common/models/TagSearch.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace common\models;
+
+use Yii;
+use yii\base\Model;
+use yii\data\ActiveDataProvider;
+use common\models\Tag;
+
+/**
+ * TagSearch represents the model behind the search form of `common\models\Tag`.
+ */
+class TagSearch extends Tag
+{
+    /**
+     * @inheritdoc
+     */
+    public function rules()
+    {
+        return [
+            [['id'], 'integer'],
+            [['tag_name', 'slug'], 'safe'],
+        ];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function scenarios()
+    {
+        // bypass scenarios() implementation in the parent class
+        return Model::scenarios();
+    }
+
+    /**
+     * Creates data provider instance with search query applied
+     *
+     * @param array $params
+     *
+     * @return ActiveDataProvider
+     */
+    public function search($params)
+    {
+        $query = Tag::find();
+
+        // add conditions that should always apply here
+
+        $dataProvider = new ActiveDataProvider([
+            'query' => $query,
+        ]);
+
+        $this->load($params);
+
+        if (!$this->validate()) {
+            // uncomment the following line if you do not want to return any records when validation fails
+            // $query->where('0=1');
+            return $dataProvider;
+        }
+
+        // grid filtering conditions
+        $query->andFilterWhere([
+            'id' => $this->id,
+        ]);
+
+        $query->andFilterWhere(['like', 'tag_name', $this->tag_name])
+            ->andFilterWhere(['like', 'slug', $this->slug]);
+
+        return $dataProvider;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         "php": ">=5.4.0",
         "yiisoft/yii2": "~2.0.6",
         "yiisoft/yii2-bootstrap": "~2.0.0",
-        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0"
+        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0",
+        "kartik-v/yii2-widget-select2": "@dev"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "630d5f1d19e73b0163f900453171fba5",
+    "content-hash": "c7d62294e8a2851353617597d01d5282",
     "packages": [
         {
             "name": "bower-asset/bootstrap",
@@ -324,6 +324,110 @@
                 "html"
             ],
             "time": "2018-02-23T01:58:20+00:00"
+        },
+        {
+            "name": "kartik-v/yii2-krajee-base",
+            "version": "v1.8.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kartik-v/yii2-krajee-base.git",
+                "reference": "0cafe6376780cedcd00f52c9d82b172d5851f6b0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kartik-v/yii2-krajee-base/zipball/0cafe6376780cedcd00f52c9d82b172d5851f6b0",
+                "reference": "0cafe6376780cedcd00f52c9d82b172d5851f6b0",
+                "shasum": ""
+            },
+            "require": {
+                "yiisoft/yii2-bootstrap": "@dev"
+            },
+            "type": "yii2-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "kartik\\base\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kartik Visweswaran",
+                    "email": "kartikv2@gmail.com",
+                    "homepage": "http://www.krajee.com/"
+                }
+            ],
+            "description": "Base library and foundation components for all Yii2 Krajee extensions.",
+            "homepage": "https://github.com/kartik-v/yii2-krajee-base",
+            "keywords": [
+                "base",
+                "extension",
+                "foundation",
+                "krajee",
+                "widget",
+                "yii2"
+            ],
+            "time": "2017-09-29T06:18:14+00:00"
+        },
+        {
+            "name": "kartik-v/yii2-widget-select2",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kartik-v/yii2-widget-select2.git",
+                "reference": "d08a5b302fe04216bd04290f0e99e26386801a37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kartik-v/yii2-widget-select2/zipball/d08a5b302fe04216bd04290f0e99e26386801a37",
+                "reference": "d08a5b302fe04216bd04290f0e99e26386801a37",
+                "shasum": ""
+            },
+            "require": {
+                "kartik-v/yii2-krajee-base": "~1.7"
+            },
+            "type": "yii2-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "kartik\\select2\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Kartik Visweswaran",
+                    "email": "kartikv2@gmail.com",
+                    "homepage": "http://www.krajee.com/"
+                }
+            ],
+            "description": "Enhanced Yii2 wrapper for the Select2 jQuery plugin (sub repo split from yii2-widgets).",
+            "homepage": "https://github.com/kartik-v/yii2-widget-select2",
+            "keywords": [
+                "dropdown",
+                "extension",
+                "form",
+                "jquery",
+                "plugin",
+                "select2",
+                "widget",
+                "yii2"
+            ],
+            "time": "2018-02-24T05:28:25+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -3195,7 +3299,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "kartik-v/yii2-widget-select2": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Создан базовый механизм добавления\удаления тегов в привязке к новостям. Для этого задействовано расширение kartik-v/yii2-widget-select2. Новые теги можно добавлять как непосредственно при создании или редактировании новости, так и заранее через круд-контроллер Тегов.